### PR TITLE
Copying the lobby code to the clipboard when clicking on the header

### DIFF
--- a/src/Managers/VersusManager.cs
+++ b/src/Managers/VersusManager.cs
@@ -245,28 +245,28 @@ internal static class VersusManager
         trigger.triggers = new Il2CppSystem.Collections.Generic.List<EventTrigger.Entry>();
 
         // On pointer enter trigger - modify header text
-        EventTrigger.Entry entryEnter = new EventTrigger.Entry { eventID = EventTriggerType.PointerEnter };
-        entryEnter.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
+        EventTrigger.Entry pointerEnter = new EventTrigger.Entry { eventID = EventTriggerType.PointerEnter };
+        pointerEnter.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
         {
             if (!copyingLobbyCode) pickSides?.SetText($"Click to Copy");
         }));
-        trigger.triggers.Add(entryEnter);
+        trigger.triggers.Add(pointerEnter);
 
         // On pointer exit trigger - reset header text
-        EventTrigger.Entry entryExit = new EventTrigger.Entry { eventID = EventTriggerType.PointerExit };
-        entryExit.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
+        EventTrigger.Entry pointerExit = new EventTrigger.Entry { eventID = EventTriggerType.PointerExit };
+        pointerExit.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
         {
             if (!copyingLobbyCode) pickSides?.SetText(defaultHeaderText);
         }));
-        trigger.triggers.Add(entryExit);
+        trigger.triggers.Add(pointerExit);
 
         // On pointer click trigger - copy the lobby code to clipboard
-        EventTrigger.Entry entryClick = new EventTrigger.Entry { eventID = EventTriggerType.PointerClick };
-        entryClick.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
+        EventTrigger.Entry pointerClick = new EventTrigger.Entry { eventID = EventTriggerType.PointerClick };
+        pointerClick.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
         {
             if (!copyingLobbyCode) MelonCoroutines.Start(CoCopyLobbyCode());
         }));
-        trigger.triggers.Add(entryClick);
+        trigger.triggers.Add(pointerClick);
     }
 
     private static IEnumerator CoCopyLobbyCode()

--- a/src/Managers/VersusManager.cs
+++ b/src/Managers/VersusManager.cs
@@ -130,9 +130,6 @@ internal static class VersusManager
     /// </summary>
     internal static void UpdateSideVisuals()
     {
-        // Exit if any UI components are missing to prevent null reference exceptions
-        if (zombiePlayer1 == null || zombiePlayer2 == null || plantPlayer1 == null || plantPlayer2 == null) return;
-
         // Clear all existing text before assigning new names
         ResetAllText();
 
@@ -145,12 +142,12 @@ internal static class VersusManager
                 if (client.AmHost)
                 {
                     // Host is assigned to the first zombie slot
-                    zombiePlayer1.SetText(client.Name);
+                    zombiePlayer1?.SetText(client.Name);
                 }
                 else
                 {
                     // Client is assigned to the second plant slot
-                    plantPlayer2.SetText(client.Name);
+                    plantPlayer2?.SetText(client.Name);
                 }
             }
 
@@ -164,12 +161,12 @@ internal static class VersusManager
                 if (client.AmHost)
                 {
                     // Host is assigned to the first plant slot
-                    plantPlayer1.SetText(client.Name);
+                    plantPlayer1?.SetText(client.Name);
                 }
                 else
                 {
                     // Client is assigned to the second zombie slot
-                    zombiePlayer2.SetText(client.Name);
+                    zombiePlayer2?.SetText(client.Name);
                 }
             }
 
@@ -198,15 +195,18 @@ internal static class VersusManager
 #endif
 
             // Enable buttons only when game is in progress (not in lobby) and there are at least 2 players
-            if (NetLobby.LobbyData.Networked.PickingSides && NetLobby.LobbyData.AllClients.Values.Count > 1)
+            if (NetLobby.LobbyData?.Networked != null)
             {
-                // Allow host to interact with side selection buttons when conditions are met
-                VsSideChoosererPatch.SetButtonsInteractable(true);
-            }
-            else
-            {
-                // Disable buttons when in lobby or with only one player
-                VsSideChoosererPatch.SetButtonsInteractable(false);
+                if (NetLobby.LobbyData.Networked.PickingSides && NetLobby.LobbyData.AllClients.Values.Count > 1)
+                {
+                    // Allow host to interact with side selection buttons when conditions are met
+                    VsSideChoosererPatch.SetButtonsInteractable(true);
+                }
+                else
+                {
+                    // Disable buttons when in lobby or with only one player
+                    VsSideChoosererPatch.SetButtonsInteractable(false);
+                }
             }
         }
     }
@@ -216,24 +216,21 @@ internal static class VersusManager
     /// </summary>
     private static void ResetAllText()
     {
-        // Safety check for null components
-        if (zombiePlayer1 == null || zombiePlayer2 == null || plantPlayer1 == null || plantPlayer2 == null) return;
-
         // Shows the lobby code in the header and resets the header UI events
         pickSides?.SetText(defaultHeaderText);
         UpdateHeaderEvents();
 
         // Ensure all text elements are visible
-        zombiePlayer1.gameObject.SetActive(true);
-        zombiePlayer2.gameObject.SetActive(true);
-        plantPlayer1.gameObject.SetActive(true);
-        plantPlayer2.gameObject.SetActive(true);
+        zombiePlayer1?.gameObject.SetActive(true);
+        zombiePlayer2?.gameObject.SetActive(true);
+        plantPlayer1?.gameObject.SetActive(true);
+        plantPlayer2?.gameObject.SetActive(true);
 
         // Clear all text content
-        zombiePlayer1.SetText(string.Empty);
-        zombiePlayer2.SetText(string.Empty);
-        plantPlayer1.SetText(string.Empty);
-        plantPlayer2.SetText(string.Empty);
+        zombiePlayer1?.SetText(string.Empty);
+        zombiePlayer2?.SetText(string.Empty);
+        plantPlayer1?.SetText(string.Empty);
+        plantPlayer2?.SetText(string.Empty);
     }
 
     /// <summary>
@@ -242,31 +239,34 @@ internal static class VersusManager
     private static void UpdateHeaderEvents()
     {
         EventTrigger trigger = lobbyCodeHeaderTrigger.GetComponent<EventTrigger>();
-        trigger.triggers = new Il2CppSystem.Collections.Generic.List<EventTrigger.Entry>();
-
-        // On pointer enter trigger - modify header text
-        EventTrigger.Entry pointerEnter = new EventTrigger.Entry { eventID = EventTriggerType.PointerEnter };
-        pointerEnter.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
+        if (trigger != null)
         {
-            if (!copyingLobbyCode) pickSides?.SetText($"Click to Copy");
-        }));
-        trigger.triggers.Add(pointerEnter);
-
-        // On pointer exit trigger - reset header text
-        EventTrigger.Entry pointerExit = new EventTrigger.Entry { eventID = EventTriggerType.PointerExit };
-        pointerExit.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
-        {
-            if (!copyingLobbyCode) pickSides?.SetText(defaultHeaderText);
-        }));
-        trigger.triggers.Add(pointerExit);
-
-        // On pointer click trigger - copy the lobby code to clipboard
-        EventTrigger.Entry pointerClick = new EventTrigger.Entry { eventID = EventTriggerType.PointerClick };
-        pointerClick.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
-        {
-            if (!copyingLobbyCode) MelonCoroutines.Start(CoCopyLobbyCode());
-        }));
-        trigger.triggers.Add(pointerClick);
+            trigger.triggers = new Il2CppSystem.Collections.Generic.List<EventTrigger.Entry>();
+    
+            // On pointer enter trigger - modify header text
+            EventTrigger.Entry pointerEnter = new EventTrigger.Entry { eventID = EventTriggerType.PointerEnter };
+            pointerEnter.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
+            {
+                if (!copyingLobbyCode) pickSides?.SetText($"Click to Copy");
+            }));
+            trigger.triggers.Add(pointerEnter);
+    
+            // On pointer exit trigger - reset header text
+            EventTrigger.Entry pointerExit = new EventTrigger.Entry { eventID = EventTriggerType.PointerExit };
+            pointerExit.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
+            {
+                if (!copyingLobbyCode) pickSides?.SetText(defaultHeaderText);
+            }));
+            trigger.triggers.Add(pointerExit);
+    
+            // On pointer click trigger - copy the lobby code to clipboard
+            EventTrigger.Entry pointerClick = new EventTrigger.Entry { eventID = EventTriggerType.PointerClick };
+            pointerClick.callback.AddListener((UnityAction<BaseEventData>)((eventData) =>
+            {
+                if (!copyingLobbyCode) MelonCoroutines.Start(CoCopyLobbyCode());
+            }));
+            trigger.triggers.Add(pointerClick);
+        }
     }
 
     private static IEnumerator CoCopyLobbyCode()

--- a/src/Managers/VersusManager.cs
+++ b/src/Managers/VersusManager.cs
@@ -1,11 +1,16 @@
-﻿using ReplantedOnline.Helper;
+﻿using Il2CppReloaded.Gameplay;
+using Il2CppTekly.PanelViews;
+using Il2CppTMPro;
+using MelonLoader;
+using ReplantedOnline.Helper;
 using ReplantedOnline.Modules;
 using ReplantedOnline.Network.Object.Game;
 using ReplantedOnline.Network.Online;
 using ReplantedOnline.Patches.UI;
 using System.Collections;
-using System.Drawing;
-using System.Numerics;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.EventSystems;
 
 namespace ReplantedOnline.Managers;
 


### PR DESCRIPTION
# Features
Added an `EventTrigger` component to the header of the team selection screen. This allows for hover enter, hover exit, and click events. These are used to change the header text and copy the lobby code to the clipboard with a coroutine on click. 
# Future Changes
Could be moved out of the `VersusManager` if it's not the best place for this functionality.
# Demonstration
Some screenshots of the ingame functionality are attached below:
<img width="1919" height="1079" alt="Screenshot_1" src="https://github.com/user-attachments/assets/a921aeee-fbd2-4a98-bcb0-cb609382c148" />
<img width="1919" height="1079" alt="Screenshot_2" src="https://github.com/user-attachments/assets/dc318670-5652-4f82-98b9-b4af7504c38b" />